### PR TITLE
Add default value {} for options argument

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -263,7 +263,7 @@ dictionary ContactsSelectOptions {
 [Exposed=(Window,SecureContext)]
 interface ContactsManager {
     Promise<sequence<ContactProperty>> getProperties();
-    Promise<sequence<ContactInfo>> select(sequence<ContactProperty> properties, optional ContactsSelectOptions options);
+    Promise<sequence<ContactInfo>> select(sequence<ContactProperty> properties, optional ContactsSelectOptions options = {});
 };
 </script>
 


### PR DESCRIPTION
This is required by https://heycam.github.io/webidl/#idl-operations:

> If the type of an argument is a dictionary type or a union type that
> has a dictionary type as one of its flattened member types, and that
> dictionary type and its ancestors have no required members, and the
> argument is either the final argument or is followed only by optional
> arguments, then the argument must be specified as optional and have a
> default value provided.